### PR TITLE
outofcontext.party games

### DIFF
--- a/config/categories.json
+++ b/config/categories.json
@@ -30,6 +30,12 @@
         "backgroundColor": "BurlyWood"
     },
     {
+        "id": "writing",
+        "name": "✍️ Writing",
+        "color": "black",
+        "backgroundColor": "Turquoise"
+    },
+    {
         "id": "netgamesio",
         "name": "💎 netgames.io",
         "color": "white",

--- a/config/games/outofcontextparty.ts
+++ b/config/games/outofcontextparty.ts
@@ -52,7 +52,7 @@ const games: Array<ServerGame> = [
             in the story, so writing with ambiguity allows for more
             interesting stories.`,
         basedOn: {
-            game: "Consequences",
+            game: "Consequences, FoldingStory",
             link: "https://en.wikipedia.org/wiki/Consequences_(game)",
         },
         category: ["writing", "easy"],

--- a/config/games/outofcontextparty.ts
+++ b/config/games/outofcontextparty.ts
@@ -1,0 +1,115 @@
+import { ServerGame } from "../../types/types";
+import { postJson } from "../../utils/utils";
+
+const gameTemplate = (
+    game: string,
+    {
+        name,
+        description,
+        basedOn,
+        category,
+        players,
+        minPlayers,
+        familyFriendly,
+        pictures,
+    }: Partial<ServerGame>
+): ServerGame => ({
+    id: "ooc-" + game,
+    name: name,
+    author: "Isaac Hirschfeld",
+    basedOn,
+    description,
+    displayUrlText: "outofcontext.party",
+    displayUrlHref: "https://www.outofcontext.party/",
+    minPlayers,
+    maxPlayers: 255,
+    category,
+    players,
+    familyFriendly,
+    pictures,
+    connectToGame: async () => {
+        const origin = "https://outofcontext.party"; // "http://localhost:8080"; // (dev)
+        const { code } = await postJson(origin + "/api/v1/rocketcrab", {
+            game,
+            version: 1,
+        });
+        return {
+            player: { url: `${origin}/lobby/${code}` },
+        };
+    },
+});
+
+const games: Array<ServerGame> = [
+    gameTemplate("story", {
+        name: "Raconteur",
+        description: `Collaborate in writing stories one line at a time with
+            minimal context.
+
+            Raconteur is inspired by improv-type games where players
+            contribute to a story one sentence or one word at a time.
+            The idea is to create unique stories from a train of thought
+            going who knows where. Continuity is held only by the last line
+            in the story, so writing with ambiguity allows for more
+            interesting stories.`,
+        basedOn: {
+            game: "Consequences",
+            link: "https://en.wikipedia.org/wiki/Consequences_(game)",
+        },
+        category: ["writing", "easy"],
+        minPlayers: 2,
+        players: "2+",
+        familyFriendly: true,
+        pictures: [
+            "https://i.imgur.com/d3qNPi4.jpg",
+            "https://i.imgur.com/yd8klf4.jpg",
+            "https://i.imgur.com/gyCBqMh.jpg",
+        ],
+    }),
+    gameTemplate("redacted", {
+        name: "Redacted",
+        description: `Collaborate in writing, tampering, and repairing
+            stories one line at a time.
+
+            Redacted is an extension upon Raconteur. Players still
+            contribute to a story, however now players are able to interact
+            with the lines other players have written. This game is meant to
+            be played after a familiarity with no context line-by-line
+            stories is established.`,
+        basedOn: null,
+        category: ["writing", "medium"],
+        minPlayers: 4,
+        players: "4+",
+        familyFriendly: true,
+        pictures: [
+            "https://i.imgur.com/n4QYeLp.jpg",
+            "https://i.imgur.com/IQ6DAhF.jpg",
+            "https://i.imgur.com/urUahk6.jpg",
+            "https://i.imgur.com/QSX70Nv.jpg",
+            "https://i.imgur.com/vaIJQwM.jpg",
+        ],
+    }),
+    gameTemplate("recipe", {
+        name: "Hodgepodge",
+        description: `Collaborate in splicing together recipes for anything.
+
+            Hodgepodge is fairly complicated in the sense that there is not a
+            single streamlined direction for each instruction set. Players
+            submit steps in a recipe following a theme, ingredients without
+            any context, and potential hazards without context. This mixture
+            of randomness and context tends to be awfully delicious.`,
+        basedOn: null,
+        category: ["writing", "medium"],
+        minPlayers: 2,
+        players: "2+",
+        familyFriendly: true,
+        pictures: [
+            "https://i.imgur.com/IAC751C.jpg",
+            "https://i.imgur.com/BvdwE7v.jpg",
+            "https://i.imgur.com/Mezk17h.jpg",
+            "https://i.imgur.com/lkD8Xbf.jpg",
+            "https://i.imgur.com/a8jCj5t.jpg",
+        ],
+    }),
+];
+
+export default games;


### PR DESCRIPTION
This PR adds 3 writing based games to rocketcrab from [outofcontext.party](https://www.outofcontext.party) and a new "Writing" category:

* Raconteur - collaboratively write stories one line at a time while only seeing the last line
* Hodgepodge - collaboratively build recipes in a similar fashion
* Redacted - Raconteur, but with extra steps in the middle to modify the previous line (collab mad lib)

outofcontext.party has been updated to support creating games from rocket crab, inheriting nicknames, and hiding the lobby code.

I didn't add the other games because Scribble (another drawphone) and Wurderer (spoon assassin with words) didn't seem necessary.

Raconteur was created without the knowledge it was based on something but I included the "flavor" of game it is in basedOn. Hodgepodge and redacted are original creations and aren't really based on anything.

At the moment, games are capped to 255 players but I've never seen a lobby with more than 20 so it's probably not a big deal.